### PR TITLE
refactor: allow passing configuration as argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,23 @@ mpesa.initiate_b2c(/* amount */ 10, /* msisdn */ 258843330333, /* transaction re
 - [ ] Reversal
 - [ ] Query Transaction Status
 
+### Using custom configuration
+
+Optionally, you can also use custom configuration to initialize the API:
+
+```js
+const mpesa = require('mpesa-node-api');
+
+mpesa.initializeApi({
+    baseUrl: "YOUR_MPESA_API_HOST",
+    apiKey: "YOUR_MPESA_API_KEY",
+    publicKey: "YOUR_MPESA_PUBLIC_KEY",
+    origin: "YOUR_MPESA_ORIGIN",
+    serviceProviderCode: "YOUR_MPESA_SERVICE_PROVIDER_CODE"
+});
+mpesa.initiate_c2b( 10, 258843330333, 'T12344C', 'ref1');
+```
+
 ## Getting a copy for development
 
 These instructions will get you a copy of the project up and running on

--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ module.exports.initiate_c2b = async function (amount, msisdn, transaction_ref, t
                 "input_CustomerMSISDN": msisdn + "",
                 "input_Amount": amount + "",
                 "input_ThirdPartyReference": thirdparty_ref,
-                "input_ServiceProviderCode": mpesaConfig.serviceProviderCode
+                "input_ServiceProviderCode": mpesaConfig.serviceProviderCode + ""
             }
         });
         return response.data;
@@ -100,7 +100,7 @@ module.exports.initiate_b2c = async function (amount, msisdn, transaction_ref, t
                 "input_CustomerMSISDN": msisdn + "",
                 "input_Amount": amount + "",
                 "input_ThirdPartyReference": thirdparty_ref,
-                "input_ServiceProviderCode": mpesaConfig.serviceProviderCode
+                "input_ServiceProviderCode": mpesaConfig.serviceProviderCode + ""
             }
         });
         return response.data;

--- a/index.js
+++ b/index.js
@@ -25,31 +25,31 @@ function initialize_api_from_dotenv() {
             serviceProviderCode: process.env.MPESA_SERVICE_PROVIDER_CODE
         };
         validateConfig(mpesaConfig);
-        console.log("Using configuration from .env file");
+        console.log("Using M-Pesa environment configuration");
     } else {
-        console.log("Using the configuration specified in initializeApi()");
+        console.log("Using custom M-Pesa configuration");
     }
 }
 
-function log_required_config_arg(argName) {
+function required_config_arg(argName) {
     return "Please provide a valid " + argName + " in the configuration when calling initializeApi()";
 }
 
 function validateConfig(configParams) {
     if (!configParams.baseUrl) {
-        throw log_required_config_arg("baseUrl")
+        throw required_config_arg("baseUrl")
     }
     if (!configParams.apiKey) {
-        throw log_required_config_arg("apiKey")
+        throw required_config_arg("apiKey")
     }
     if (!configParams.publicKey) {
-        throw log_required_config_arg("publicKey")
+        throw required_config_arg("publicKey")
     }
     if (!configParams.origin) {
-        throw log_required_config_arg("origin")
+        throw required_config_arg("origin")
     }
     if (!configParams.serviceProviderCode) {
-        throw log_required_config_arg("serviceProviderCode")
+        throw required_config_arg("serviceProviderCode")
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ function initialize_api_from_dotenv() {
             origin: process.env.MPESA_ORIGIN,
             serviceProviderCode: process.env.MPESA_SERVICE_PROVIDER_CODE
         };
+        validateConfig(mpesaConfig);
         console.log("Using configuration from .env file");
     } else {
         console.log("Using the configuration specified in initializeApi()");
@@ -34,7 +35,7 @@ function log_required_config_arg(argName) {
     return "Please provide a valid " + argName + " in the configuration when calling initializeApi()";
 }
 
-module.exports.initializeApi = function (configParams) {
+function validateConfig(configParams) {
     if (!configParams.baseUrl) {
         throw log_required_config_arg("baseUrl")
     }
@@ -50,6 +51,10 @@ module.exports.initializeApi = function (configParams) {
     if (!configParams.serviceProviderCode) {
         throw log_required_config_arg("serviceProviderCode")
     }
+}
+
+module.exports.initializeApi = function (configParams) {
+    validateConfig(configParams);
     mpesaConfig = configParams;
 };
 

--- a/index.js
+++ b/index.js
@@ -3,9 +3,7 @@ const axios = require('axios').default;
 const crypto = require('crypto');
 const constants = require('constants');
 
-const MP_BASE_URL = process.env.MPESA_API_HOST;
-const MP_API_KEY = process.env.MPESA_API_KEY;
-const MP_PUBLIC_KEY = process.env.MPESA_PUBLIC_KEY;
+let mpesaConfig;
 
 function _getBearerToken(mpesa_public_key, mpesa_api_key) {
     const publicKey = "-----BEGIN PUBLIC KEY-----\n"+mpesa_public_key+"\n"+"-----END PUBLIC KEY-----";
@@ -17,23 +15,62 @@ function _getBearerToken(mpesa_public_key, mpesa_api_key) {
     return encrypted.toString("base64");
 }
 
+function initialize_api_from_dotenv() {
+    if (!mpesaConfig) {
+        mpesaConfig = {
+            baseUrl: process.env.MPESA_API_HOST,
+            apiKey: process.env.MPESA_API_KEY,
+            publicKey: process.env.MPESA_PUBLIC_KEY,
+            origin: process.env.MPESA_ORIGIN,
+            serviceProviderCode: process.env.MPESA_SERVICE_PROVIDER_CODE
+        };
+        console.log("Using configuration from .env file");
+    } else {
+        console.log("Using the configuration specified in initializeApi()");
+    }
+}
+
+function log_required_config_arg(argName) {
+    return "Please provide a valid " + argName + " in the configuration when calling initializeApi()";
+}
+
+module.exports.initializeApi = function (configParams) {
+    if (!configParams.baseUrl) {
+        throw log_required_config_arg("baseUrl")
+    }
+    if (!configParams.apiKey) {
+        throw log_required_config_arg("apiKey")
+    }
+    if (!configParams.publicKey) {
+        throw log_required_config_arg("publicKey")
+    }
+    if (!configParams.origin) {
+        throw log_required_config_arg("origin")
+    }
+    if (!configParams.serviceProviderCode) {
+        throw log_required_config_arg("serviceProviderCode")
+    }
+    mpesaConfig = configParams;
+};
+
 module.exports.initiate_c2b = async function (amount, msisdn, transaction_ref, thirdparty_ref) {
+    initialize_api_from_dotenv();
     try {
         let response;
         response = await axios({
             method: 'post',
-            url: 'https://' + MP_BASE_URL + ':18352/ipg/v1x/c2bPayment/singleStage/',
+            url: 'https://' + mpesaConfig.baseUrl + ':18352/ipg/v1x/c2bPayment/singleStage/',
             headers: {
                 'Content-Type': 'application/json',
-                'Authorization': 'Bearer ' + _getBearerToken(MP_PUBLIC_KEY, MP_API_KEY),
-                'Origin': process.env.MPESA_ORIGIN
+                'Authorization': 'Bearer ' + _getBearerToken(mpesaConfig.publicKey, mpesaConfig.apiKey),
+                'Origin': mpesaConfig.origin
             },
             data: {
                 "input_TransactionReference": transaction_ref,
                 "input_CustomerMSISDN": msisdn + "",
                 "input_Amount": amount + "",
                 "input_ThirdPartyReference": thirdparty_ref,
-                "input_ServiceProviderCode": process.env.MPESA_SERVICE_PROVIDER_CODE
+                "input_ServiceProviderCode": mpesaConfig.serviceProviderCode
             }
         });
         return response.data;
@@ -47,22 +84,23 @@ module.exports.initiate_c2b = async function (amount, msisdn, transaction_ref, t
 };
 
 module.exports.initiate_b2c = async function (amount, msisdn, transaction_ref, thirdparty_ref) {
+    initialize_api_from_dotenv();
     try {
         let response;
         response = await axios({
             method: 'post',
-            url: 'https://' + MP_BASE_URL + ':18345/ipg/v1x/b2cPayment/',
+            url: 'https://' + mpesaConfig.baseUrl + ':18345/ipg/v1x/b2cPayment/',
             headers: {
                 'Content-Type': 'application/json',
-                'Authorization': 'Bearer ' + _getBearerToken(MP_PUBLIC_KEY, MP_API_KEY),
-                'Origin': process.env.MPESA_ORIGIN
+                'Authorization': 'Bearer ' + _getBearerToken(mpesaConfig.publicKey, mpesaConfig.apiKey),
+                'Origin': mpesaConfig.origin
             },
             data: {
                 "input_TransactionReference": transaction_ref,
                 "input_CustomerMSISDN": msisdn + "",
                 "input_Amount": amount + "",
                 "input_ThirdPartyReference": thirdparty_ref,
-                "input_ServiceProviderCode": process.env.MPESA_SERVICE_PROVIDER_CODE
+                "input_ServiceProviderCode": mpesaConfig.serviceProviderCode
             }
         });
         return response.data;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Node.js library for M-Pesa API (Mozambique)",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha"
   },
   "repository": {
     "type": "git",
@@ -24,5 +24,9 @@
     "constants": "0.0.2",
     "crypto": "^1.0.1",
     "dotenv": "^8.2.0"
+  },
+  "devDependencies": {
+    "chai": "^4.2.0",
+    "mocha": "^8.0.1"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,28 @@
+const mpesa = require('../index');
+const expect = require('chai').expect;
+
+describe('config', function () {
+    describe('initializeApi throws an error when required config is missing', function () {
+        const actualConfig = {
+            baseUrl: "api.mpesa.co.mz"
+        };
+        try {
+            mpesa.initializeApi(actualConfig)
+        } catch (e) {
+            expect(e).to.equal('Please provide a valid apiKey in the configuration when calling initializeApi()')
+        }
+    });
+
+    describe('initializeApi works with valid config', function () {
+        const actualConfig = {
+            baseUrl: "api.mpesa.co.mz",
+            apiKey: "apiKey",
+            publicKey: "key",
+            origin: "developer.mpesa.co.mz",
+            serviceProviderCode: 171717
+        };
+        expect(function () {
+            mpesa.initializeApi(actualConfig)
+        }).to.not.throw();
+    });
+});

--- a/test/test.js
+++ b/test/test.js
@@ -2,7 +2,7 @@ const mpesa = require('../index');
 const expect = require('chai').expect;
 
 describe('config', function () {
-    describe('initializeApi throws an error when required config is missing', function () {
+    it('initializeApi throws an error when required config is missing', function () {
         const actualConfig = {
             baseUrl: "api.mpesa.co.mz"
         };
@@ -13,7 +13,7 @@ describe('config', function () {
         }
     });
 
-    describe('initializeApi works with valid config', function () {
+    it('initializeApi works with valid config', function () {
         const actualConfig = {
             baseUrl: "api.mpesa.co.mz",
             apiKey: "apiKey",


### PR DESCRIPTION
This should allow developers to pass custom configuration in case:
- .env is not supported in their environment;
- they need faster ways to update configuration for testing purposes.

TODO:
- [ ] Test this throughout
- [x] Update README.md to mention this change